### PR TITLE
Making the regexes for strong and emphasized text a bit more foolproof.

### DIFF
--- a/markdown-code-for-wordpress.php
+++ b/markdown-code-for-wordpress.php
@@ -43,8 +43,8 @@
 function mdc_the_content( $content ) {
 
 	$content = preg_replace( '/`(.*?)`/', '<code>$1</code>', $content );
-	$content = preg_replace( '/\*\*(.+?)\*\*/s', '<strong>$1</strong>', $content );
-	$content = preg_replace( '/\*([^\*]+)\*/', '<em>$1</em>', $content );
+	$content = preg_replace( '/\*\*([^*\s].*?)\*\*/s', '<strong>$1</strong>', $content );
+	$content = preg_replace( '/\*([^*\s].*?)\*/', '<em>$1</em>', $content );
 
 	return $content;
 


### PR DESCRIPTION
An intentional single asterisk after a word should not be considered the start of emphasized text. Also, whole lines of asterisks (edge case) should be left untouched.

Basically the ‘trick’ is to make sure the opening asterisk(s) are not followed by a space or even more asterisks.

I’m sure many more edge cases can be thought of to [break the regexes](http://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags?answertab=votes#tab-top) but it should be a bit more solid with these tweaks.
